### PR TITLE
Update Dockerfile-ubuntu

### DIFF
--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -7,11 +7,11 @@ RUN apt install maven -y &&\
 RUN apt install -y wget 
 RUN wget https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.8/bin/apache-tomcat-9.0.8.tar.gz
 RUN mkdir /opt/tomcat &&\
-    mv apache-tomcat-9.0.8.tar.gz /opt/tomcat &&\
-    tar -xvzf /opt/tomcat/apache-tomcat-9.0.8.tar.gz
+    tar -xvzf apache-tomcat-9.0.8.tar.gz -C /opt/tomcat --strip-components=1 &&\
+    rm apache-tomcat-9.0.8.tar.gz
 RUN groupadd tomcat &&\
     useradd -s /bin/false -g tomcat -d /opt/tomcat tomcat
-RUN cd /opt/tomcat/apache-tomcat-9.0.8 &&\
-    chmod 777 conf bin &&\
-    chown -R tomcat webapps/ work/ temp/ logs/ bin/
-ENTRYPOINT ["sh","/opt/tomcat/apache-tomcat-9.0.8/bin/startup.sh"]
+RUN chmod 755 /opt/tomcat/conf /opt/tomcat/bin &&\
+    chown -R tomcat:tomcat /opt/tomcat/webapps/ /opt/tomcat/work/ /opt/tomcat/temp/ /opt/tomcat/logs/ /opt/tomcat/bin/ &&\
+    chmod +x /opt/tomcat/bin/*.sh
+ENTRYPOINT ["sh","/opt/tomcat/bin/startup.sh"]


### PR DESCRIPTION
Key changes made:

Fixed tar extraction: Used -C /opt/tomcat --strip-components=1 to extract directly into /opt/tomcat/
Removed tar file: Added rm apache-tomcat-9.0.8.tar.gz to clean up
Fixed permissions: Changed from 777 to 755 for better security
Fixed chown: Added group specification (tomcat:tomcat)
Updated paths: Since we're extracting directly to /opt/tomcat/, the path is now /opt/tomcat/bin/startup.sh
Added executable permissions: chmod +x /opt/tomcat/bin/*.sh to ensure startup scripts are executable